### PR TITLE
added count_ones function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,7 @@ impl FixedBitSet
     {
         let start = range.start().unwrap_or(0);
         let end = range.end().unwrap_or(self.length);
-        // range makes sure that range.start <= range.end
-        assert!(end <= self.length);
+        assert!(start <= end && end <= self.length);
         let (first_block, first_rem) = div_rem(start, BITS);
         let (last_block, last_rem) = div_rem(end, BITS);
         let mut sum = 0usize;
@@ -300,6 +299,23 @@ fn count_ones() {
     assert_eq!(fb.count_ones(70..96), 2);
     assert_eq!(fb.count_ones(70..99), 2);
     assert_eq!(fb.count_ones(..), 9);
+    assert_eq!(fb.count_ones(0..100), 9);
+    assert_eq!(fb.count_ones(0..0), 0);
+    assert_eq!(fb.count_ones(100..100), 0);
+}
+
+#[should_panic]
+#[test]
+fn count_ones_oob() {
+    let fb = FixedBitSet::with_capacity(100);
+    fb.count_ones(90..101);
+}
+
+#[should_panic]
+#[test]
+fn count_ones_negative_range() {
+    let fb = FixedBitSet::with_capacity(100);
+    fb.count_ones(90..80);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,9 +147,9 @@ impl FixedBitSet
     pub fn count_ones<T: IndexRange>(&self, range: T) -> usize
     {
         let start = range.start().unwrap_or(0);
-        let end = range.end().unwrap_or(self.length - 1);
+        let end = range.end().unwrap_or(self.length);
         // range makes sure that range.start <= range.end
-        assert!(end < self.length);
+        assert!(end <= self.length);
         let (first_block, first_rem) = div_rem(start, BITS);
         let (last_block, last_rem) = div_rem(end, BITS);
         let mut sum = 0usize;
@@ -285,6 +285,7 @@ fn count_ones() {
     fb.set(77, true);
     fb.set(95, true);
     fb.set(50, true);
+    fb.set(99, true);
     assert_eq!(fb.count_ones(..7), 0);
     assert_eq!(fb.count_ones(..8), 1);
     assert_eq!(fb.count_ones(..11), 1);
@@ -294,10 +295,11 @@ fn count_ones() {
     assert_eq!(fb.count_ones(..36), 4);
     assert_eq!(fb.count_ones(..40), 4);
     assert_eq!(fb.count_ones(..41), 5);
-    assert_eq!(fb.count_ones(50..), 3);
+    assert_eq!(fb.count_ones(50..), 4);
     assert_eq!(fb.count_ones(70..95), 1);
     assert_eq!(fb.count_ones(70..96), 2);
-    assert_eq!(fb.count_ones(..), 8);
+    assert_eq!(fb.count_ones(70..99), 2);
+    assert_eq!(fb.count_ones(..), 9);
 }
 
 #[test]

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,0 +1,39 @@
+use std::ops::{
+    RangeFull,
+    RangeFrom,
+    RangeTo,
+    Range,
+};
+
+// Taken from https://github.com/bluss/odds/blob/master/src/range.rs.
+
+/// **IndexRange** is implemented by Rust's built-in range types, produced
+/// by range syntax like `..`, `a..`, `..b` or `c..d`.
+pub trait IndexRange<T=usize> {
+    #[inline]
+    /// Start index (inclusive)
+    fn start(&self) -> Option<T> { None }
+    #[inline]
+    /// End index (exclusive)
+    fn end(&self) -> Option<T> { None }
+}
+
+
+impl<T> IndexRange<T> for RangeFull {}
+
+impl<T: Copy> IndexRange<T> for RangeFrom<T> {
+    #[inline]
+    fn start(&self) -> Option<T> { Some(self.start) }
+}
+
+impl<T: Copy> IndexRange<T> for RangeTo<T> {
+    #[inline]
+    fn end(&self) -> Option<T> { Some(self.end) }
+}
+
+impl<T: Copy> IndexRange<T> for Range<T> {
+    #[inline]
+    fn start(&self) -> Option<T> { Some(self.start) }
+    #[inline]
+    fn end(&self) -> Option<T> { Some(self.end) }
+}


### PR DESCRIPTION
This solves #4. Please note that proposed implementation can most probably be further optimized (for example if the remainder is 0 then we can completely skip `mask` creation and `sum` modification). Please let me know what do you think about this @bluss.