### PR TITLE
Add iter_ones() method plus benchmarks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ documentation = "https://docs.rs/fixedbitset/"
 repository = "https://github.com/bluss/fixedbitset"
 
 keywords = ["container", "data-structure", "bitvec", "bitset"]
+
+[features]
+unstable = []
+


### PR DESCRIPTION
You can run benchmarks using ```cargo bench --features=unstable```. I tried using ```u32::trailing_zeros()```, but this was much slower (1700 vs. 450) for the worst case (all 1's). Not sure if it were using a real CPU instruction, or emulated it.

Now this is what I get on my computer using ```rustc 1.12.0-dev (e360f70f3 2016-08-08)```:

```
test bench::bench_iter_ones_all_ones                      ... bench:     456,531 ns/iter (+/- 39,400)
test bench::bench_iter_ones_all_zeros                     ... bench:      30,476 ns/iter (+/- 297)
test bench::bench_iter_ones_using_contains_all_ones       ... bench:     766,082 ns/iter (+/- 38,058)
test bench::bench_iter_ones_using_contains_all_zeros      ... bench:     695,486 ns/iter (+/- 13,244)
test bench::bench_iter_ones_using_slice_directly_all_ones ... bench:     566,271 ns/iter (+/- 7,478)
test bench::bench_iter_ones_using_slice_directly_all_zero ... bench:      28,930 ns/iter (+/- 293)
```