### PR TITLE
inline count_ones()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ impl FixedBitSet
     /// Use `..` to count the whole content of the bitset.
     ///
     /// **Panics** if the range extends past the end of the bitset.
+    #[inline]
     pub fn count_ones<T: IndexRange>(&self, range: T) -> usize
     {
         let start = range.start().unwrap_or(0);
@@ -157,6 +158,7 @@ impl FixedBitSet
         self.count_ones_impl(start, end)
     }
 
+    #[inline]
     fn count_ones_impl(&self, start: usize, end: usize) -> usize {
         let (first_block, first_rem) = div_rem(start, BITS);
         let (last_block, last_rem) = div_rem(end, BITS);


### PR DESCRIPTION
This small PR fixes lack of inlining in `count_ones`. During profiling of some hot code which used `count_ones` i noticed that both `count_ones` and `count_ones_impl` are not tagged as `#[inline]` which can lead to significant performance loss if you call them in a tight loop. Note that almost all, if not all methods of `fixedbitset` are tagged as `#[inline]`.