### PR TITLE
Added `insert_range`, `set_range` functions.

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -47,7 +47,7 @@ fn bench_iter_ones_using_contains_all_zeros(b: &mut Bencher) {
 fn bench_iter_ones_using_contains_all_ones(b: &mut Bencher) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
-    for i in 0..N { fb.insert(i); }
+    fb.insert_range(..);
 
     b.iter(|| {
         let mut count = 0;
@@ -72,7 +72,7 @@ fn bench_iter_ones_using_slice_directly_all_zero(b: &mut Bencher) {
 fn bench_iter_ones_using_slice_directly_all_ones(b: &mut Bencher) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
-    for i in 0..N { fb.insert(i); }
+    fb.insert_range(..);
 
     b.iter(|| {
        let mut count = 0;
@@ -99,7 +99,7 @@ fn bench_iter_ones_all_zeros(b: &mut Bencher) {
 fn bench_iter_ones_all_ones(b: &mut Bencher) {
     const N: usize = 1_000_000;
     let mut fb = FixedBitSet::with_capacity(N);
-    for i in 0..N { fb.insert(i); }
+    fb.insert_range(..);
 
     b.iter(|| {
         let mut count = 0;
@@ -110,3 +110,27 @@ fn bench_iter_ones_all_ones(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn bench_insert_range(b: &mut Bencher) {
+    const N: usize = 1_000_000;
+    let mut fb = FixedBitSet::with_capacity(N);
+
+    b.iter(|| {
+        test::black_box({
+            fb.insert_range(..);
+        });
+    });
+}
+
+#[bench]
+#[ignore] // just for comparison with `bench_insert_range`.
+fn bench_insert_range_using_loop(b: &mut Bencher) {
+    const N: usize = 1_000_000;
+    let mut fb = FixedBitSet::with_capacity(N);
+
+    b.iter(|| {
+        test::black_box(for i in 0..N {
+            fb.insert(i);
+        });
+    });
+}


### PR DESCRIPTION
This is used to quickly set a range of bits to ones, especially the whole bit set. This is much more efficient (~100x) than loop-and-insert.

----

Benchmarks for this commit:

```
test bench_insert_range                            ... bench:      11,929 ns/iter (+/- 3,610)
test bench_insert_range_using_loop                 ... bench:   1,603,755 ns/iter (+/- 425,971)
test bench_iter_ones_all_ones                      ... bench:   3,214,317 ns/iter (+/- 319,040)
test bench_iter_ones_all_zeros                     ... bench:      67,466 ns/iter (+/- 20,117)
test bench_iter_ones_using_contains_all_ones       ... bench:     865,560 ns/iter (+/- 375,256)
test bench_iter_ones_using_contains_all_zeros      ... bench:     769,844 ns/iter (+/- 308,139)
test bench_iter_ones_using_slice_directly_all_ones ... bench:     720,331 ns/iter (+/- 288,132)
test bench_iter_ones_using_slice_directly_all_zero ... bench:      37,800 ns/iter (+/- 10,259)
```

(Benchmarks for 0.1.6 (master) for reference, though not relevant for this PR):

```
test bench_iter_ones_all_ones                      ... bench:   3,336,585 ns/iter (+/- 455,084)
test bench_iter_ones_all_zeros                     ... bench:      68,508 ns/iter (+/- 18,640)
test bench_iter_ones_using_contains_all_ones       ... bench:     893,454 ns/iter (+/- 148,149)
test bench_iter_ones_using_contains_all_zeros      ... bench:     780,992 ns/iter (+/- 333,253)
test bench_iter_ones_using_slice_directly_all_ones ... bench:     737,119 ns/iter (+/- 123,984)
test bench_iter_ones_using_slice_directly_all_zero ... bench:      36,513 ns/iter (+/- 5,356)
```
