### PR TITLE
Add BitXor, BitXorAssign, and symmetric difference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,8 +557,8 @@ impl <'a> BitAnd for &'a FixedBitSet
             }
         };
         let mut data = short.clone();
-        for (i, &block) in long.iter().take(short.len()).enumerate() {
-            data[i] &= block;
+        for (data, block) in data.iter_mut().zip(long.iter()) {
+            *data &= block;
         }
         let len = std::cmp::min(self.len(), other.len());
         FixedBitSet{data: data, length: len}
@@ -585,8 +585,8 @@ impl <'a> BitOr for &'a FixedBitSet
             }
         };
         let mut data = long.clone();
-        for (i, &block) in short.iter().enumerate() {
-            data[i] |= block;
+        for (data, block) in data.iter_mut().zip(short.iter()) {
+            *data |= block;
         }
         let len = std::cmp::max(self.len(), other.len());
         FixedBitSet{data: data, length: len}
@@ -612,8 +612,8 @@ impl <'a> BitXor for &'a FixedBitSet
             }
         };
         let mut data = long.clone();
-        for (i, &block) in short.iter().enumerate() {
-            data[i] ^= block;
+        for (data, block) in data.iter_mut().zip(short.iter()) {
+            *data ^= block;
         }
         let len = std::cmp::max(self.len(), other.len());
         FixedBitSet{data: data, length: len}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,7 +558,7 @@ impl <'a> BitAnd for &'a FixedBitSet
         };
         let mut data = short.clone();
         for (data, block) in data.iter_mut().zip(long.iter()) {
-            *data &= block;
+            *data &= *block;
         }
         let len = std::cmp::min(self.len(), other.len());
         FixedBitSet{data: data, length: len}
@@ -586,7 +586,7 @@ impl <'a> BitOr for &'a FixedBitSet
         };
         let mut data = long.clone();
         for (data, block) in data.iter_mut().zip(short.iter()) {
-            *data |= block;
+            *data |= *block;
         }
         let len = std::cmp::max(self.len(), other.len());
         FixedBitSet{data: data, length: len}
@@ -613,7 +613,7 @@ impl <'a> BitXor for &'a FixedBitSet
         };
         let mut data = long.clone();
         for (data, block) in data.iter_mut().zip(short.iter()) {
-            *data ^= block;
+            *data ^= *block;
         }
         let len = std::cmp::max(self.len(), other.len());
         FixedBitSet{data: data, length: len}


### PR DESCRIPTION
Adds a symmetric_difference operation like in the `std::collections` sets, as well as the analogous BitXor operations.