### PR TITLE
Added no_std feature switch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+.idea/
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.12.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+    - rust: nightly
+      env:
+      - FEATURES='no_std'
 branches:
   only:
     - master
 script:
   - |
-      cargo build --verbose &&
-      cargo test --verbose &&
-      cargo test --verbose --release
+      cargo build --verbose --features "$FEATURES" &&
+      cargo test --verbose --features "$FEATURES" &&
+      cargo test --verbose --release --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "fixedbitset"
 version = "0.1.9"
-authors = ["bluss"]
+authors = ["bluss", "jonimake"]
 license = "MIT/Apache-2.0"
 
 description = "FixedBitSet is a simple bitset collection"
 documentation = "https://docs.rs/fixedbitset/"
 repository = "https://github.com/bluss/fixedbitset"
 
-keywords = ["container", "data-structure", "bitvec", "bitset"]
+keywords = ["container", "data-structure", "bitvec", "bitset", "no_std"]
 categories = ["data-structures"]
 
 [package.metadata.release]
 no-dev-version = true
 
+[features]
+no_std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fixedbitset"
 version = "0.1.9"
-authors = ["bluss", "jonimake"]
+authors = ["bluss"]
 license = "MIT/Apache-2.0"
 
 description = "FixedBitSet is a simple bitset collection"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,20 @@
 //! `FixedBitSet` is a simple fixed size set of bits.
 #![doc(html_root_url="https://docs.rs/fixedbitset/0.1/")]
 
+#![cfg_attr(feature = "no_std", feature(alloc))]
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[cfg(feature = "no_std")]
+extern crate alloc;
+#[cfg(feature = "no_std")]
+use alloc::{
+    vec,
+    prelude::*,
+};
+
+#[cfg(feature = "no_std")]
+use core as std;
+
 mod range;
 
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index};
@@ -650,7 +664,7 @@ impl <'a> BitXorAssign for FixedBitSet
 fn it_works() {
     const N: usize = 50;
     let mut fb = FixedBitSet::with_capacity(N);
-    println!("{:?}", fb);
+    
 
     for i in 0..(N + 10) {
         assert_eq!(fb.contains(i), false);
@@ -661,7 +675,7 @@ fn it_works() {
     fb.set(12, false);
     fb.set(12, true);
     fb.set(N-1, true);
-    println!("{:?}", fb);
+    
     assert!(fb.contains(10));
     assert!(!fb.contains(11));
     assert!(fb.contains(12));
@@ -1155,7 +1169,7 @@ fn bitand_assign_shorter() {
     let b = b_ones.iter().cloned().collect::<FixedBitSet>();
     a &= b;
     let res = a.ones().collect::<Vec<usize>>();
-    println!("{:?}\n{:?}", &res, &a_and_b);
+    
     assert!(res == a_and_b);
 }
 
@@ -1325,8 +1339,8 @@ fn from_iterator_ones() {
     }
     fb.put(len - 1);
     let dup = fb.ones().collect::<FixedBitSet>();
-    println!("{0:?}\n{1:?}", fb, dup);
-    println!("{0:?}\n{1:?}", fb.ones().collect::<Vec<usize>>(), dup.ones().collect::<Vec<usize>>());
+    
+    
     assert_eq!(fb.len(), dup.len());
     assert_eq!(fb.ones().collect::<Vec<usize>>(), dup.ones().collect::<Vec<usize>>());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 #[cfg(feature = "no_std")]
 use alloc::{
     vec,
-    prelude::*,
+    vec::Vec,
 };
 
 #[cfg(feature = "no_std")]


### PR DESCRIPTION
Types from core module are used instead of std when no_std feature is
enabled. This also enables alloc feature and uses alloc crate. Removed
println statements from tests since they don't work in no_std.